### PR TITLE
fix(core): clone metadata-only X509 certificates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Cloning an `X509Certificate` model that contains certificate metadata without an underlying Java certificate no
+  longer throws a `NullPointerException`; metadata-only and certificate-backed models now both preserve their state
+  when cloned ([#2527](https://github.com/mock-server/mockserver-monorepo/issues/2527)).
 - JSON body matching no longer depends on which JSON provider [json-unit](https://github.com/lukas-krecan/JsonUnit)
   resolves to. MockServer parses both documents with Jackson and hands json-unit the resulting nodes to avoid
   re-parsing on every match, but json-unit picks its provider by asking each in turn whether it claims the value
@@ -5221,7 +5224,6 @@ This cycle centres on **first-class LLM / AI-agent mocking** and a major **platf
 - ensure port binding exception are thrown and MockServer stops if port already allocated
 - fixed log configuration to ensure no class loading exception thrown
 - fixed control plane matching of expectations with notted entries
-
 
 
 

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/model/X509Certificate.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/model/X509Certificate.java
@@ -86,12 +86,15 @@ public class X509Certificate extends ObjectWithJsonToString {
 
     @SuppressWarnings("MethodDoesntCallSuperMethod")
     public X509Certificate clone() {
-        return x509Certificate()
-            .withCertificate(certificate)
+        X509Certificate clonedCertificate = x509Certificate()
             .withIssuerDistinguishedName(issuerDistinguishedName)
             .withSubjectDistinguishedName(subjectDistinguishedName)
             .withSerialNumber(serialNumber)
             .withSignatureAlgorithmName(signatureAlgorithmName);
+        if (certificate != null) {
+            clonedCertificate.withCertificate(certificate);
+        }
+        return clonedCertificate;
     }
 
     @Override

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/model/X509CertificateTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/model/X509CertificateTest.java
@@ -1,0 +1,53 @@
+package org.mockserver.model;
+
+import org.junit.Test;
+import org.mockserver.socket.tls.PEMToFile;
+
+import java.security.cert.Certificate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockserver.model.X509Certificate.x509Certificate;
+
+public class X509CertificateTest {
+
+    @Test
+    public void shouldCloneMetadataOnlyCertificate() {
+        // given
+        X509Certificate certificate = x509Certificate()
+            .withIssuerDistinguishedName("someIssuer")
+            .withSubjectDistinguishedName("someSubject")
+            .withSerialNumber("someSerialNumber")
+            .withSignatureAlgorithmName("someSignatureAlgorithm");
+
+        // when
+        X509Certificate clonedCertificate = certificate.clone();
+
+        // then
+        assertThat(clonedCertificate, is(certificate));
+        assertThat(clonedCertificate, not(sameInstance(certificate)));
+        assertThat(clonedCertificate.getCertificate(), is(nullValue()));
+        assertThat(clonedCertificate.getCertificateBytes(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldCloneCertificateWithUnderlyingCertificate() {
+        // given
+        Certificate underlyingCertificate = PEMToFile.x509ChainFromPEMFile("org/mockserver/authentication/mtls/leaf-cert.pem").get(0);
+        X509Certificate certificate = x509Certificate()
+            .withCertificate(underlyingCertificate)
+            .withIssuerDistinguishedName("someIssuer")
+            .withSubjectDistinguishedName("someSubject")
+            .withSerialNumber("someSerialNumber")
+            .withSignatureAlgorithmName("someSignatureAlgorithm");
+
+        // when
+        X509Certificate clonedCertificate = certificate.clone();
+
+        // then
+        assertThat(clonedCertificate, is(certificate));
+        assertThat(clonedCertificate, not(sameInstance(certificate)));
+        assertThat(clonedCertificate.getCertificate(), is(sameInstance(underlyingCertificate)));
+        assertThat(clonedCertificate.getCertificateBytes(), is(certificate.getCertificateBytes()));
+    }
+}


### PR DESCRIPTION
## What & why

`X509Certificate.clone()` currently calls `withCertificate(certificate)` unconditionally. Metadata-only certificate models have no underlying `java.security.cert.Certificate`, so cloning them passes `null` to `withCertificate(...)` and fails while encoding the certificate.

This change:

- clones the metadata fields before handling the optional certificate;
- calls `withCertificate(...)` only when the source has an underlying certificate;
- adds regression coverage for metadata-only and certificate-backed models;
- records the fix in the Unreleased changelog.

Fixes #2527

## Where

- [x] `mockserver/mockserver-core`
- [ ] `mockserver/mockserver-netty`
- [ ] Client library (Java / Node / Python / Ruby)
- [ ] Dashboard UI (`mockserver-ui`)
- [ ] Build / CI / infrastructure
- [ ] Documentation only
- [ ] Other (describe above)

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and (for non-trivial changes) opened an issue first to discuss the approach.
- [x] The change is made at the architecturally correct layer (root cause, not the symptom).
- [x] Tests added or updated for the new behaviour, and the relevant module's focused tests pass locally.
- [x] User-facing changes have a `changelog.md` entry under `## [Unreleased]` (prefixed `BREAKING:` if applicable).
- [x] User-facing changes update the consumer docs (`jekyll-www.mock-server.com/`) and/or internal docs (`docs/`) where relevant. No documentation change is relevant because this changes no public API, configuration, or documented workflow.
- [x] Code targets **Java 17** (no APIs newer than Java 17; `jakarta.*` namespace where applicable).
- [x] No secrets, credentials, or private endpoints are included in the diff.

## Notes for reviewers

Validation command:

```shell
./mvnw -pl mockserver-core -am \
  -Dtest=org.mockserver.model.X509CertificateTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Results:

- `X509CertificateTest`: 2 tests passed in the default Surefire phase;
- `X509CertificateTest`: 2 tests passed in the sequential Surefire phase;
- Checkstyle: 0 violations in the reactor modules;
- `git diff --check`: passed.
