### PR TITLE
feat: add OrcaRouter as an OpenAI-chat-compatible LLM provider

### DIFF
--- a/docs/code/llm-mocking.md
+++ b/docs/code/llm-mocking.md
@@ -51,10 +51,11 @@ Currently registered codecs:
 | DEEPSEEK | `DeepSeekCodec` | Complete (delegates to `OpenAiChatCompletionsCodec`) |
 | GROQ | `GroqCodec` | Complete (delegates to `OpenAiChatCompletionsCodec`) |
 | OPENROUTER | `OpenRouterCodec` | Complete (delegates to `OpenAiChatCompletionsCodec`) |
+| ORCAROUTER | `OrcaRouterCodec` | Complete (delegates to `OpenAiChatCompletionsCodec`) |
 
 ### OpenAI-compatible provider aliases
 
-`MISTRAL`, `XAI` (Grok), `DEEPSEEK`, `GROQ`, and `OPENROUTER` expose the OpenAI Chat Completions wire format on their own hosts. Their codecs extend `OpenAiCompatibleChatCodec` (which delegates every encode/decode to `OpenAiChatCompletionsCodec`, exactly like `AzureOpenAiCodec`) and their runtime clients extend `OpenAiLlmClient` (overriding only `provider()` and `defaultBaseUrl()`). Because the path is the shared `/chat/completions`, the **host** is the only distinguishing signal: `LlmProviderSniffer` (live forward/proxy path) and `ProviderDetector` (offline AUTO detection) map `api.mistral.ai`→`MISTRAL`, `api.x.ai`→`XAI`, `api.deepseek.com`→`DEEPSEEK`, `api.groq.com`→`GROQ`, `openrouter.ai`→`OPENROUTER`. This means proxy observability records traffic to these gateways as LLM (provider-correct GenAI spans + cost metrics) instead of dropping it as non-LLM. Pricing rows in `LlmPricing` are marked **approximate** (`isApproximate()`); OpenRouter routes vendor-prefixed model ids (`openai/…`, `anthropic/…`, `google/…`, `mistral*/…`, `x-ai/…`, `deepseek/…`) to the underlying vendor's table. Their wire shape is byte-identical to the `openai` golden fixtures, so they are covered by `OpenAiCompatibleProviderCodecTest` rather than dedicated golden files.
+`MISTRAL`, `XAI` (Grok), `DEEPSEEK`, `GROQ`, `OPENROUTER`, and `ORCAROUTER` expose the OpenAI Chat Completions wire format on their own hosts. Their codecs extend `OpenAiCompatibleChatCodec` (which delegates every encode/decode to `OpenAiChatCompletionsCodec`, exactly like `AzureOpenAiCodec`) and their runtime clients extend `OpenAiLlmClient` (overriding only `provider()` and `defaultBaseUrl()`). Because the path is the shared `/chat/completions`, the **host** is the only distinguishing signal: `LlmProviderSniffer` (live forward/proxy path) and `ProviderDetector` (offline AUTO detection) map `api.mistral.ai`→`MISTRAL`, `api.x.ai`→`XAI`, `api.deepseek.com`→`DEEPSEEK`, `api.groq.com`→`GROQ`, `openrouter.ai`→`OPENROUTER`, `api.orcarouter.ai`→`ORCAROUTER`. This means proxy observability records traffic to these gateways as LLM (provider-correct GenAI spans + cost metrics) instead of dropping it as non-LLM. Pricing rows in `LlmPricing` are marked **approximate** (`isApproximate()`); OpenRouter and OrcaRouter route vendor-prefixed model ids (`openai/…`, `anthropic/…`, `google/…`, `mistral*/…`, `x-ai/…`, `deepseek/…`) to the underlying vendor's table. Their wire shape is byte-identical to the `openai` golden fixtures, so they are covered by `OpenAiCompatibleProviderCodecTest` rather than dedicated golden files.
 
 ## Realtime voice APIs (OpenAI Realtime, Gemini Live)
 
@@ -462,6 +463,7 @@ classDiagram
         DEEPSEEK
         GROQ
         OPENROUTER
+        ORCAROUTER
     }
     class ConversationPredicates {
         +turnIndex: Integer

--- a/mockserver-jetbrains/src/main/kotlin/com/mockserver/jetbrains/LlmCompletion.kt
+++ b/mockserver-jetbrains/src/main/kotlin/com/mockserver/jetbrains/LlmCompletion.kt
@@ -41,6 +41,7 @@ object LlmCompletion {
         "DEEPSEEK",
         "GROQ",
         "OPENROUTER",
+        "ORCAROUTER",
     )
 
     /** Representative model names per provider, for quick scaffolding. */

--- a/mockserver-jetbrains/src/main/resources/schemas/mockserver-expectation.schema.json
+++ b/mockserver-jetbrains/src/main/resources/schemas/mockserver-expectation.schema.json
@@ -1347,7 +1347,8 @@
             "XAI",
             "DEEPSEEK",
             "GROQ",
-            "OPENROUTER"
+            "OPENROUTER",
+            "ORCAROUTER"
           ]
         },
         "model": {

--- a/mockserver-vscode/schemas/mockserver-expectation.schema.json
+++ b/mockserver-vscode/schemas/mockserver-expectation.schema.json
@@ -1347,7 +1347,8 @@
             "XAI",
             "DEEPSEEK",
             "GROQ",
-            "OPENROUTER"
+            "OPENROUTER",
+            "ORCAROUTER"
           ]
         },
         "model": {

--- a/mockserver-vscode/src/llmCompletion.ts
+++ b/mockserver-vscode/src/llmCompletion.ts
@@ -37,6 +37,7 @@ export const LLM_PROVIDERS = [
     "DEEPSEEK",
     "GROQ",
     "OPENROUTER",
+    "ORCAROUTER",
 ];
 
 /** Representative model names per provider, for quick scaffolding. */

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/LlmContentFilterBodies.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/LlmContentFilterBodies.java
@@ -102,6 +102,7 @@ public final class LlmContentFilterBodies {
             case DEEPSEEK:
             case GROQ:
             case OPENROUTER:
+            case ORCAROUTER:
                 return openAiBlock();
             case GEMINI:
                 return geminiBlock();

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/ProviderCodecRegistry.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/ProviderCodecRegistry.java
@@ -12,6 +12,7 @@ import org.mockserver.llm.codec.OllamaCodec;
 import org.mockserver.llm.codec.OpenAiChatCompletionsCodec;
 import org.mockserver.llm.codec.OpenAiResponsesCodec;
 import org.mockserver.llm.codec.OpenRouterCodec;
+import org.mockserver.llm.codec.OrcaRouterCodec;
 import org.mockserver.llm.codec.VoyageCodec;
 import org.mockserver.llm.codec.XaiCodec;
 import org.mockserver.model.Provider;
@@ -43,6 +44,7 @@ public class ProviderCodecRegistry {
         INSTANCE.register(new DeepSeekCodec());
         INSTANCE.register(new GroqCodec());
         INSTANCE.register(new OpenRouterCodec());
+        INSTANCE.register(new OrcaRouterCodec());
     }
 
     private final ConcurrentHashMap<Provider, ProviderCodec> codecs = new ConcurrentHashMap<>();

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/ProviderDetector.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/ProviderDetector.java
@@ -104,6 +104,8 @@ public final class ProviderDetector {
                 return Optional.of(Provider.GROQ);
             case "openrouter.ai":
                 return Optional.of(Provider.OPENROUTER);
+            case "api.orcarouter.ai":
+                return Optional.of(Provider.ORCAROUTER);
             default:
                 return Optional.empty();
         }

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/LlmClientRegistry.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/LlmClientRegistry.java
@@ -33,6 +33,7 @@ public class LlmClientRegistry {
         INSTANCE.register(new DeepSeekLlmClient());
         INSTANCE.register(new GroqLlmClient());
         INSTANCE.register(new OpenRouterLlmClient());
+        INSTANCE.register(new OrcaRouterLlmClient());
     }
 
     private final ConcurrentHashMap<Provider, LlmClient> clients = new ConcurrentHashMap<>();

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/LlmProviderSniffer.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/LlmProviderSniffer.java
@@ -407,6 +407,9 @@ public final class LlmProviderSniffer {
         if (lowerHost.equals("openrouter.ai")) {
             return Optional.of(Provider.OPENROUTER);
         }
+        if (lowerHost.equals("api.orcarouter.ai")) {
+            return Optional.of(Provider.ORCAROUTER);
+        }
         if (isBedrockHost(lowerHost)) {
             return Optional.of(Provider.BEDROCK);
         }

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/OpenAiLlmClient.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/OpenAiLlmClient.java
@@ -26,7 +26,7 @@ public class OpenAiLlmClient extends AbstractLlmClient {
 
     /**
      * The default base URL used when the backend does not supply one. OpenAI-compatible
-     * subclasses (Mistral, xAI, DeepSeek, Groq, OpenRouter) override this to point at
+     * subclasses (Mistral, xAI, DeepSeek, Groq, OpenRouter, OrcaRouter) override this to point at
      * their own host while inheriting the identical request/response wire format.
      */
     protected String defaultBaseUrl() {

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/OrcaRouterLlmClient.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/client/OrcaRouterLlmClient.java
@@ -1,0 +1,22 @@
+package org.mockserver.llm.client;
+
+import org.mockserver.model.Provider;
+
+/**
+ * Runtime client for OrcaRouter. OpenAI-chat-compatible, so it inherits request
+ * building and response parsing from {@link OpenAiLlmClient}. The default base URL
+ * ({@code https://api.orcarouter.ai}) combines with the inherited
+ * {@code /v1/chat/completions} path to reach the Chat Completions endpoint.
+ */
+public class OrcaRouterLlmClient extends OpenAiLlmClient {
+
+    @Override
+    public Provider provider() {
+        return Provider.ORCAROUTER;
+    }
+
+    @Override
+    protected String defaultBaseUrl() {
+        return "https://api.orcarouter.ai";
+    }
+}

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/codec/OpenAiCompatibleChatCodec.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/codec/OpenAiCompatibleChatCodec.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 /**
  * Base codec for OpenAI-chat-compatible providers (Mistral, xAI/Grok, DeepSeek,
- * Groq, OpenRouter). These providers expose the OpenAI Chat Completions wire format
+ * Groq, OpenRouter, OrcaRouter). These providers expose the OpenAI Chat Completions wire format
  * ({@code POST /v1/chat/completions}, {@code Authorization: Bearer}) on a different
  * host, so — exactly like {@link AzureOpenAiCodec} — all encoding and decoding
  * delegates to {@link OpenAiChatCompletionsCodec}; only {@link #provider()} differs

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/codec/OrcaRouterCodec.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/codec/OrcaRouterCodec.java
@@ -1,0 +1,17 @@
+package org.mockserver.llm.codec;
+
+import org.mockserver.model.Provider;
+
+/**
+ * Codec for OrcaRouter ({@code api.orcarouter.ai}). OrcaRouter exposes an
+ * OpenAI-compatible chat API ({@code /v1/chat/completions}) that fronts many
+ * upstream models, so all encoding/decoding delegates to
+ * {@link OpenAiChatCompletionsCodec} via {@link OpenAiCompatibleChatCodec}.
+ */
+public class OrcaRouterCodec extends OpenAiCompatibleChatCodec {
+
+    @Override
+    public Provider provider() {
+        return Provider.ORCAROUTER;
+    }
+}

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/llm/cost/LlmPricing.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/llm/cost/LlmPricing.java
@@ -244,6 +244,11 @@ public final class LlmPricing {
                 // Route to the underlying vendor's table by stripping the prefix, so the
                 // pass-through price is approximated. Unknown/unprefixed ids resolve to null.
                 return openRouterPricing(model);
+            case ORCAROUTER:
+                // OrcaRouter also fronts many upstream models with vendor-prefixed ids
+                // (e.g. "anthropic/claude-sonnet-5", "anthropic/claude-opus-5"), so it uses
+                // the same prefix-stripping approximation as OpenRouter.
+                return openRouterPricing(model);
             default:
                 return null;
         }

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/model/Provider.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/model/Provider.java
@@ -17,5 +17,6 @@ public enum Provider {
     XAI,
     DEEPSEEK,
     GROQ,
-    OPENROUTER
+    OPENROUTER,
+    ORCAROUTER
 }

--- a/mockserver/mockserver-core/src/main/resources/org/mockserver/model/schema/httpLlmResponse.json
+++ b/mockserver/mockserver-core/src/main/resources/org/mockserver/model/schema/httpLlmResponse.json
@@ -22,7 +22,8 @@
         "XAI",
         "DEEPSEEK",
         "GROQ",
-        "OPENROUTER"
+        "OPENROUTER",
+        "ORCAROUTER"
       ]
     },
     "model": {

--- a/mockserver/mockserver-core/src/main/resources/org/mockserver/openapi/mock-server-openapi-embedded-model.yaml
+++ b/mockserver/mockserver-core/src/main/resources/org/mockserver/openapi/mock-server-openapi-embedded-model.yaml
@@ -7091,6 +7091,7 @@ components:
             - DEEPSEEK
             - GROQ
             - OPENROUTER
+            - ORCAROUTER
         model:
           type: string
         completion:

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/llm/LlmContentFilterBodiesTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/llm/LlmContentFilterBodiesTest.java
@@ -50,7 +50,7 @@ public class LlmContentFilterBodiesTest {
 
     @Test
     public void openAiCompatibleProvidersUseOpenAiBlock() {
-        for (Provider provider : new Provider[]{Provider.OPENAI_RESPONSES, Provider.MISTRAL, Provider.XAI, Provider.DEEPSEEK, Provider.GROQ, Provider.OPENROUTER}) {
+        for (Provider provider : new Provider[]{Provider.OPENAI_RESPONSES, Provider.MISTRAL, Provider.XAI, Provider.DEEPSEEK, Provider.GROQ, Provider.OPENROUTER, Provider.ORCAROUTER}) {
             LlmContentFilterBodies.Block block = LlmContentFilterBodies.blockFor(provider, null);
             assertThat(provider + " status", block.getStatusCode(), is(400));
             assertThat(provider + " body", block.getJsonBody(), containsString("content_filter"));

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/llm/ProviderCodecRegistryTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/llm/ProviderCodecRegistryTest.java
@@ -126,9 +126,9 @@ public class ProviderCodecRegistryTest {
         // when
         List<String> names = registry.supportedProviderNames();
 
-        // then — all 14 providers should be registered (7 chat + 2 rerank-only + 5
+        // then — all 15 providers should be registered (7 chat + 2 rerank-only + 6
         // OpenAI-chat-compatible aliases)
-        assertThat(names, hasSize(14));
+        assertThat(names, hasSize(15));
         assertThat(names, containsInAnyOrder(
             "ANTHROPIC",
             "OPENAI",
@@ -143,7 +143,8 @@ public class ProviderCodecRegistryTest {
             "XAI",
             "DEEPSEEK",
             "GROQ",
-            "OPENROUTER"
+            "OPENROUTER",
+            "ORCAROUTER"
         ));
     }
 

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/llm/codec/LlmCodecGoldenFileTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/llm/codec/LlmCodecGoldenFileTest.java
@@ -81,7 +81,7 @@ public class LlmCodecGoldenFileTest {
 
     /**
      * OpenAI-chat-compatible alias providers (Mistral, xAI/Grok, DeepSeek, Groq,
-     * OpenRouter). Their codecs delegate to {@code OpenAiChatCompletionsCodec}, so
+     * OpenRouter, OrcaRouter). Their codecs delegate to {@code OpenAiChatCompletionsCodec}, so
      * their wire shape is byte-identical to the {@code openai} fixtures already
      * asserted here — dedicated golden files would be pure duplicates. They are
      * instead exercised by {@code OpenAiCompatibleProviderCodecTest}, which proves
@@ -90,7 +90,8 @@ public class LlmCodecGoldenFileTest {
      */
     private static final Set<Provider> OPENAI_COMPATIBLE_ALIAS_PROVIDERS =
         Collections.unmodifiableSet(EnumSet.of(
-            Provider.MISTRAL, Provider.XAI, Provider.DEEPSEEK, Provider.GROQ, Provider.OPENROUTER));
+            Provider.MISTRAL, Provider.XAI, Provider.DEEPSEEK, Provider.GROQ, Provider.OPENROUTER,
+            Provider.ORCAROUTER));
 
     /**
      * Map Provider enum to fixture directory name.

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/llm/codec/LlmCodecStructuralContractTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/llm/codec/LlmCodecStructuralContractTest.java
@@ -89,7 +89,7 @@ public class LlmCodecStructuralContractTest {
     /**
      * The seven chat/completion providers whose wire body/streaming shape this
      * test pins. Rerank-only (Cohere, Voyage) and OpenAI-chat-compatible aliases
-     * (Mistral, xAI, DeepSeek, Groq, OpenRouter) are excluded for the same
+     * (Mistral, xAI, DeepSeek, Groq, OpenRouter, OrcaRouter) are excluded for the same
      * reasons documented in {@link LlmCodecGoldenFileTest}.
      */
     private static final Set<Provider> CHAT_PROVIDERS =

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/llm/codec/OpenAiCompatibleProviderCodecTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/llm/codec/OpenAiCompatibleProviderCodecTest.java
@@ -25,7 +25,7 @@ import static org.mockserver.model.HttpRequest.request;
 
 /**
  * Covers the OpenAI-chat-compatible alias providers (Mistral, xAI/Grok, DeepSeek,
- * Groq, OpenRouter): codec delegation, registry/client registration, host-based
+ * Groq, OpenRouter, OrcaRouter): codec delegation, registry/client registration, host-based
  * provider detection (sniffer + detector), and pricing rows.
  */
 public class OpenAiCompatibleProviderCodecTest {
@@ -33,7 +33,8 @@ public class OpenAiCompatibleProviderCodecTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final Provider[] ALIASES = {
-        Provider.MISTRAL, Provider.XAI, Provider.DEEPSEEK, Provider.GROQ, Provider.OPENROUTER
+        Provider.MISTRAL, Provider.XAI, Provider.DEEPSEEK, Provider.GROQ, Provider.OPENROUTER,
+        Provider.ORCAROUTER
     };
 
     // --- codec delegation ----------------------------------------------------
@@ -96,6 +97,7 @@ public class OpenAiCompatibleProviderCodecTest {
         assertThat(LlmProviderSniffer.sniffByHost("api.deepseek.com"), is(Optional.of(Provider.DEEPSEEK)));
         assertThat(LlmProviderSniffer.sniffByHost("api.groq.com"), is(Optional.of(Provider.GROQ)));
         assertThat(LlmProviderSniffer.sniffByHost("openrouter.ai"), is(Optional.of(Provider.OPENROUTER)));
+        assertThat(LlmProviderSniffer.sniffByHost("api.orcarouter.ai"), is(Optional.of(Provider.ORCAROUTER)));
     }
 
     @Test
@@ -117,6 +119,7 @@ public class OpenAiCompatibleProviderCodecTest {
         assertThat(ProviderDetector.detectFromHost("api.deepseek.com"), is(Optional.of(Provider.DEEPSEEK)));
         assertThat(ProviderDetector.detectFromHost("api.groq.com"), is(Optional.of(Provider.GROQ)));
         assertThat(ProviderDetector.detectFromHost("openrouter.ai"), is(Optional.of(Provider.OPENROUTER)));
+        assertThat(ProviderDetector.detectFromHost("api.orcarouter.ai"), is(Optional.of(Provider.ORCAROUTER)));
     }
 
     @Test
@@ -165,5 +168,15 @@ public class OpenAiCompatibleProviderCodecTest {
             is(closeTo(18.0, 1e-9)));
         // A bare (unprefixed) id is unpriceable for OpenRouter.
         assertThat(LlmPricing.getPricing(Provider.OPENROUTER, "gpt-4o"), is(nullValue()));
+    }
+
+    @Test
+    public void orcaRouterRoutesVendorPrefixedModelsToTheUnderlyingTable() {
+        // OrcaRouter mirrors OpenRouter: vendor-prefixed ids route to the underlying
+        // vendor's table, so anthropic/claude-sonnet-4-x → Anthropic sonnet-4 3 + 15 = 18.
+        assertThat(LlmPricing.estimateCostUsd(Provider.ORCAROUTER, "anthropic/claude-sonnet-4-x", 1_000_000, 1_000_000),
+            is(closeTo(18.0, 1e-9)));
+        // A bare (unprefixed) id is unpriceable for OrcaRouter too.
+        assertThat(LlmPricing.getPricing(Provider.ORCAROUTER, "claude-sonnet-5"), is(nullValue()));
     }
 }

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/model/HttpLlmResponseTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/model/HttpLlmResponseTest.java
@@ -174,7 +174,7 @@ public class HttpLlmResponseTest {
     @Test
     public void shouldCoverAllProviderEnumValues() {
         // verify all provider enum values exist
-        assertThat(Provider.values().length, is(14));
+        assertThat(Provider.values().length, is(15));
         assertThat(Provider.valueOf("ANTHROPIC"), is(Provider.ANTHROPIC));
         assertThat(Provider.valueOf("OPENAI"), is(Provider.OPENAI));
         assertThat(Provider.valueOf("OPENAI_RESPONSES"), is(Provider.OPENAI_RESPONSES));
@@ -189,5 +189,6 @@ public class HttpLlmResponseTest {
         assertThat(Provider.valueOf("DEEPSEEK"), is(Provider.DEEPSEEK));
         assertThat(Provider.valueOf("GROQ"), is(Provider.GROQ));
         assertThat(Provider.valueOf("OPENROUTER"), is(Provider.OPENROUTER));
+        assertThat(Provider.valueOf("ORCAROUTER"), is(Provider.ORCAROUTER));
     }
 }


### PR DESCRIPTION
## Add OrcaRouter as an OpenAI-chat-compatible LLM provider

This PR adds [OrcaRouter](https://www.orcarouter.ai) to MockServer's LLM mocking feature as a first-class provider, mirroring the existing OpenRouter wiring exactly.

OrcaRouter is an AI gateway that fronts many upstream models (`anthropic/claude-*`, `openai/*`, etc.) behind a single OpenAI-compatible Chat Completions endpoint (`https://api.orcarouter.ai/v1/chat/completions`), so it slots into the existing OpenAI-chat-compatible provider pattern:

- **`Provider.ORCAROUTER`** added to the `Provider` enum alongside `OPENROUTER`
- **`OrcaRouterLlmClient`** (`org.mockserver.llm.client`) extends `OpenAiLlmClient`, overriding only `provider()` and `defaultBaseUrl()` to `https://api.orcarouter.ai`
- **`OrcaRouterCodec`** (`org.mockserver.llm.codec`) extends `OpenAiCompatibleChatCodec`, delegating all encode/decode to `OpenAiChatCompletionsCodec`
- Registered in `LlmClientRegistry` and `ProviderCodecRegistry`
- **Host detection**: `LlmProviderSniffer` and `ProviderDetector` map `api.orcarouter.ai` → `ORCAROUTER`, so forwarded/proxied traffic to the gateway is recorded as LLM (provider-correct GenAI spans + cost metrics) instead of being dropped
- **Pricing**: `LlmPricing` routes OrcaRouter's vendor-prefixed model ids (`anthropic/…`, `openai/…`, …) through the same prefix-stripping approximation already used for OpenRouter
- **Schemas & completion lists**: `httpLlmResponse.json`, the embedded OpenAPI model, both VSCode and JetBrains expectation schemas, and the `LLM_PROVIDERS` completion catalogues
- **Tests**: extended `OpenAiCompatibleProviderCodecTest`, `ProviderCodecRegistryTest`, `LlmContentFilterBodiesTest`, and `HttpLlmResponseTest` to cover the new provider; the parity test (`ProviderSchemaEnumParityTest`) enforces enum/schema/registry lockstep automatically

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.
