### PR TITLE
test(ci): verify the fork pull-request test pipeline (do not merge)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -140,3 +140,5 @@ mockserver-monorepo/
 - **SwaggerHub API:** https://app.swaggerhub.com/apis/jamesdbloom/mock-server-openapi
 - **Buildkite:** https://buildkite.com/mockserver/mockserver
 - **Snyk:** https://app.snyk.io/org/mockserver/projects
+
+<!-- CI verification: temporary no-op change used to prove the fork pull-request test pipeline triggers and passes. This PR is not intended to merge. -->


### PR DESCRIPTION
Temporary verification PR — **not for merge**, will be closed once it has served its purpose.

The new fork-PR test workflow (`.github/workflows/pr-tests.yml`) has so far only ever been run via `workflow_dispatch`, which satisfies its trigger condition through the `workflow_dispatch` branch of the OR. The other branch — `github.event.pull_request.head.repo.fork == true`, the line that actually makes this work for outside contributors — has never once been evaluated.

This PR opens from a genuine fork with a no-op documentation change, to confirm end to end that:

1. the workflow triggers on a `pull_request` event from a fork,
2. the fork condition evaluates true and the job runs,
3. the run has no access to repository secrets (read-only token),
4. a valid, non-failing change reports a **passing** check.

Closing afterwards; the fork will be deleted.